### PR TITLE
Allow for only one of 'country' or 'indicator' to be a list

### DIFF
--- a/python/tradingeconomics/historical.py
+++ b/python/tradingeconomics/historical.py
@@ -159,7 +159,7 @@ def getHistoricalData(country = None, indicator = None, initDate= None, endDate=
     else:
         ssl._create_default_https_context = _create_unverified_https_context
 
-    if type(country) is str or type(indicator) is str: 
+    if type(country) is str and type(indicator) is str: 
         linkAPI = 'https://api.tradingeconomics.com/historical/country/' + quote(country)  + '/indicator/' + quote(indicator) 
     else:
         linkAPI = paramCheck(country, indicator)


### PR DESCRIPTION
As of now, you cannot query a single country and a list of indicators. The workaround is using a list with a single item, but this is suboptimal, and the fix is trivial.