### PR TITLE
Update __init__.py

### DIFF
--- a/python/tradingeconomics/__init__.py
+++ b/python/tradingeconomics/__init__.py
@@ -20,7 +20,7 @@ if PY3: # Python 3+
     from .earnings import getEarnings, getEarningsType
     from .news import getNews, getArticles, getArticleId 
     from .worldBank import getWBCategories, getWBIndicator, getWBCountry, getWBHistorical
-    from .comtrade import getCmtCategories, getCmtCountry, getCmtHistorical, getCmtTwoCountries, getCmtUpdates, getCmtCountryByCategory, getTotalByType, getCmtCountryFilterByType
+    from .comtrade import getCmtCategories, getCmtCountry, getCmtHistorical, getCmtTwoCountries, getCmtUpdates, getCmtCountryByCategory, getCmtCountryFilterByType
     from .federalReserve import getFedRStates, getFedRSnaps, getFedRHistorical, getFedRCounty
     from .eurostat import getEurostatData,getEurostatCountries,getEurostatCategoryGroups
     from .historicalEurostat import getHistoricalEurostat
@@ -42,7 +42,7 @@ else: # Python 2.X
     from earnings import getEarnings, getEarningsType
     from news import getNews, getArticles, getArticleId
     from worldBank import getWBCategories, getWBIndicator, getWBCountry, getWBHistorical
-    from comtrade import getCmtCategories, getCmtCountry, getCmtHistorical, getCmtTwoCountries, getCmtUpdates, getCmtCountryByCategory, getTotalByType, getCmtCountryFilterByType
+    from comtrade import getCmtCategories, getCmtCountry, getCmtHistorical, getCmtTwoCountries, getCmtUpdates, getCmtCountryByCategory, getCmtCountryFilterByType
     from federalReserve import getFedRStates, getFedRSnaps, getFedRHistorical, getFedRCounty
     from eurostat import getEurostatData,getEurostatCountries,getEurostatCategoryGroups
     from historicalEurostat import getHistoricalEurostat


### PR DESCRIPTION
Needed to remove getTotalByType from __init__.py because it was removed from tradingeconomics.comtrade in most recent version update. Otherwise import error received "ImportError: cannot import name 'getTotalByType' from 'tradingeconomics.comtrade' (/Users/.../python3.7/site-packages/tradingeconomics/comtrade.py)"